### PR TITLE
Fix LegacyKeyValueFormat warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ LABEL "rating"="Five Stars" "class"="First Class"
 
 USER root
 
-ENV AP /data/app
-ENV SCPATH /etc/supervisor/conf.d
+ENV AP=/data/app
+ENV SCPATH=/etc/supervisor/conf.d
 
 RUN apt-get -y update
 


### PR DESCRIPTION
The old way of declaring environment variables is now flagged as a warning "LegacyKeyValueFormat". 
The update change the declaration of two environment variables based on the official documentation.

Reference: https://docs.docker.com/reference/build-checks/legacy-key-value-format/ .